### PR TITLE
chore: add .prettierrc matching eslint preferences

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+}


### PR DESCRIPTION
Adds a .prettierrc matching the current eslint preferences. IIRC, there is way to integrate the two directly with plugins, however, this is good quickfix to start.