### PR TITLE
`yarn reset`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,10 @@ import Config from 'react-native-config';
 const token = Config.SLACK_BOT_TOKEN;
 ```
 
+### Debugging
+
+Sometimes `watchman` is overly aggressive with the files it caches, leading to changes not being reflected in the app. If you experience an error without explanation, or errors related to `haste` or `watchman` indicated on the red debug screen on your simulator, try running:
+
+    $ yarn reset
+
 ### Designs

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint-watch": "esw -w --changed",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
+    "reset": "./reset.sh",
     "test": "jest"
   },
   "jest": {

--- a/reset.sh
+++ b/reset.sh
@@ -1,0 +1,16 @@
+# This script cleans out all yarn deps, and clears all caches React Native, Haste, and Jest use
+watchman watch-del-all &&
+rm -rf $TMPDIR/react-native-packager-cache-* &&
+rm -rf $TMPDIR/metro-bundler-cache-* &&
+watchman shutdown-server &&
+rm -rf $TMPDIR/react-* &&
+rm -rf $TMPDIR/jest* &&
+rm -rf $TMPDIR/haste-map-react-native-packager-* &&
+rm -rf $TMPDIR/metro-bundler-* &&
+rm -rf .jest &&
+rm -rf ios/build/ModuleCache/* &&
+rm -rf node_modules/ &&
+yarn cache clean &&
+yarn &&
+echo -e '⚡ You must manually terminate this process after you see the "Metro Bundler ready." message.' &&
+node node_modules/react-native/local-cli/cli.js start --reset-cache


### PR DESCRIPTION
Adds a `yarn reset` script to help mitigate watchman caching issues.

This script was influenced by a [number](https://gist.github.com/nhancv/d0502bfb0eae29a1ff30c1228a9226cb) [of](https://gist.github.com/EQuimper/a14c19461b7018dabca2dd6c3f123671) [different](https://gist.github.com/jarretmoses/c2e4786fd342b3444f3bc6beff32098d) scripts.

From the command line, run `yarn reset`.

The deprecation warnings can be safely ignored for now:

> DeprecationWarning: Buffer() is deprecated due to security
> and usability issues.
