### PR TITLE
feat: listen to any messages or mentions in slack

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import Welcome from './src/containers/Welcome/index';
-import { SlackButton, SlackDM } from './src/components/slack';
+import { SlackButton, listenToMentions } from './src/components/slack';
 
 
 const styles = StyleSheet.create({
@@ -14,12 +14,19 @@ const styles = StyleSheet.create({
 });
 
 export default class App extends React.Component {
+  initSlackServices = () => {
+    listenToMentions();
+  }
+
+  componentDidMount = () => {
+    this.initSlackServices();
+  }
+
   render() {
     return (
       <View style={styles.container}>
         <Welcome />
         <SlackButton />
-        <SlackDM />
       </View>
     );
   }

--- a/src/components/slack.js
+++ b/src/components/slack.js
@@ -56,6 +56,33 @@ const getUsersFromChannel = async (channelName) => {
   }
 };
 
+
+const connectWebSocket = url => (
+  new Promise(((resolve, reject) => {
+    /* eslint-disable-next-line */
+    const server = new WebSocket(url);
+    server.onopen = () => {
+      resolve(server);
+    };
+    server.onerror = (err) => {
+      reject(err);
+    };
+  }))
+);
+
+export const listenToMentions = async () => {
+  const { ok, url } = await slack.rtm.connect({ token: botToken });
+  if (!ok) {
+    throw new Error('Failed to connect to slack');
+  }
+  const server = await connectWebSocket(url);
+
+  server.onmessage = console.log;
+  server.onerror = (err) => {
+    throw new Error(err);
+  };
+};
+
 const sendDirectMessageToUser = (userArray, message) => {
   const slackIds = userArray.map(user => user.slackID);
   if (userArray.length === 1) {


### PR DESCRIPTION
This PR allows the slack bot to connect and listen for any messages or activity in slack. For now, I use a button to connect the slackbot up, for testing purposes.
![screen shot 2018-08-02 at 2 48 58 pm](https://user-images.githubusercontent.com/30498954/43604365-924d9326-9663-11e8-81be-d46cc84ab348.png)
<img width="790" alt="screen shot 2018-08-02 at 2 48 52 pm" src="https://user-images.githubusercontent.com/30498954/43604369-96cfa358-9663-11e8-93c8-0f01bd8f1829.png">
<img width="1136" alt="screen shot 2018-08-02 at 2 48 31 pm" src="https://user-images.githubusercontent.com/30498954/43604372-992555f8-9663-11e8-9bf1-6dfac96f9089.png">
<img width="720" alt="screen shot 2018-08-02 at 2 48 43 pm" src="https://user-images.githubusercontent.com/30498954/43604379-9ab938da-9663-11e8-9d96-f7556541c045.png">
