### PR TITLE
chore: switch circle ci to yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,17 +17,19 @@ jobs:
 
       # Download and cache dependencies
       - restore_cache:
+          name: Restore Yarn Package Cache
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - yarn-packages-{{ checksum "yarn.lock" }}
 
-      - run: yarn install
+      - run:
+          name: Install Dependencies
+          command: yarn install
 
       - save_cache:
+          name: Save Yarn Package Cache
+          key: yarn-packages-{{ checksum "yarn.lock" }}
           paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+            - ~/.cache/yarn
         
       - run: yarn run lint
 


### PR DESCRIPTION
The default circle ci depends on package.json which may not catch yarn package updates in `yarn.lock`. This PR updates the CircleCI caching to work against `yarn.lock` so we don't accidentally used all package version.