### PR TITLE
Install date-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "rnpm": {
     "assets": [
-	    "./assets/fonts"
+      "./assets/fonts"
     ]
   },
   "scripts": {
@@ -39,6 +39,7 @@
     }
   },
   "dependencies": {
+    "date-fns": "^1.29.0",
     "eslint": "^5.1.0",
     "querystring": "^0.2.0",
     "react": "16.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2063,6 +2063,10 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.0.0"
     whatwg-url "^6.4.0"
 
+date-fns@^1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
+
 debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
This PR installs the Javascript date utility library date-fns for date formatting, also fixes formatting for package.json