### PR TITLE
fix: stretch wavy lint background image to full width

### DIFF
--- a/src/components/root-view.js
+++ b/src/components/root-view.js
@@ -2,12 +2,17 @@ import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 
-export const RootView = ({ children }) => (
-  <View style={{ ...StyleSheet.absoluteFillObject }}>{children}</View>
+export const RootView = ({ children, style }) => (
+  <View style={{ ...StyleSheet.absoluteFillObject, ...style }}>{children}</View>
 );
 
 RootView.propTypes = {
   children: PropTypes.node.isRequired,
+  style: View.propTypes.style,
+};
+
+RootView.defaultProps = {
+  style: {},
 };
 
 export default RootView;

--- a/src/containers/Welcome/index.js
+++ b/src/containers/Welcome/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet } from 'react-native';
+import { View } from 'react-native';
 import {
   Heading,
   SubHeading,
@@ -10,6 +10,12 @@ import {
 } from '../../styles/pages/welcome';
 import { RootView } from '../../components/root-view';
 import WavyLines from '../../constants/images/wavy-lines.png';
+
+const BottomAnchoredBackgroundImage = () => (
+  <RootView style={{ flexDirection: 'row' }}>
+    <Background source={WavyLines} />
+  </RootView>
+);
 
 export default class Welcome extends React.Component {
   static propTypes = {
@@ -26,17 +32,7 @@ export default class Welcome extends React.Component {
   render() {
     return (
       <RootView>
-        <View
-          style={{
-            ...StyleSheet.absoluteFillObject,
-            flexDirection: 'row',
-          }}
-        >
-          <Background
-            /* eslint-disable-next-line */
-            source={WavyLines}
-          />
-        </View>
+        <BottomAnchoredBackgroundImage />
         <View style={{ flex: 1 }}>
           <Heading>Sign in here.</Heading>
           <SubHeading>

--- a/src/containers/Welcome/index.js
+++ b/src/containers/Welcome/index.js
@@ -8,6 +8,7 @@ import {
   Background,
   InputWrapper,
 } from '../../styles/pages/welcome';
+import { RootView } from '../../components/root-view';
 import WavyLines from '../../constants/images/wavy-lines.png';
 
 export default class Welcome extends React.Component {
@@ -24,11 +25,7 @@ export default class Welcome extends React.Component {
 
   render() {
     return (
-      <View
-        style={{
-          ...StyleSheet.absoluteFillObject,
-        }}
-      >
+      <RootView>
         <View
           style={{
             ...StyleSheet.absoluteFillObject,
@@ -49,7 +46,7 @@ export default class Welcome extends React.Component {
             <NameInput placeholder="What&apos;s your name?" />
           </InputWrapper>
         </View>
-      </View>
+      </RootView>
     );
   }
 }

--- a/src/containers/Welcome/index.js
+++ b/src/containers/Welcome/index.js
@@ -12,7 +12,7 @@ import { RootView } from '../../components/root-view';
 import WavyLines from '../../constants/images/wavy-lines.png';
 
 const BottomAnchoredBackgroundImage = () => (
-  <RootView style={{ flexDirection: 'row' }}>
+  <RootView style={{ top: null }}>
     <Background source={WavyLines} />
   </RootView>
 );

--- a/src/styles/pages/welcome.js
+++ b/src/styles/pages/welcome.js
@@ -31,8 +31,8 @@ export const NameInput = styled.TextInput`
 `;
 
 export const Background = styled.Image`
-  resize-mode: contain;
-  align-self: flex-end;
+  resize-mode: stretch;
+  width: 100%;
 `;
 
 export const InputWrapper = styled.View`


### PR DESCRIPTION
The strategy I used is to absolutely position the containing view
on the bottom of screen with an auto height (setting top to null
restores that default behavior). The image is then stretched to
fill that container which should result in a consistent display
on any device.

![selection_017](https://user-images.githubusercontent.com/524850/44309529-21113d80-a396-11e8-814c-c0b8fba473e2.png)

Note: this needs to be tested on an iOS device first since I don't have the environment available.