### PR TITLE
Fix Search Bar

### DIFF
--- a/src/components/search.js
+++ b/src/components/search.js
@@ -23,7 +23,7 @@ const Search = ({
             removeFunction={removeFunction}
           />
           <Style.SearchBar
-            placeholder=""
+            placeholder={selectedMojos.length >= 2 ? '' : 'Search'}
             autoCapitalize="words"
             autoCorrect={false}
             value={inputText}

--- a/src/containers/Employees/style.js
+++ b/src/containers/Employees/style.js
@@ -93,6 +93,7 @@ export const Search = styled.View`
 `;
 
 export const SearchBar = styled.TextInput`
+  flex: 1;
   font-size: ${fontSizes.medium};
   font-family: ${fonts.GTAmericaReg};
   color: ${colors.grey};


### PR DESCRIPTION
This PR fixes the search bar component. Before this fix, the TextInput did not stretch to fill its container, so when a user began typing it would squish the content to the left, making it out of view for the user who is typing.